### PR TITLE
Fix Roboto slab to Roboto Slab

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -119,7 +119,7 @@
 					]
 				},
 				{
-					"fontFamily": "Roboto slab",
+					"fontFamily": "Roboto Slab",
 					"name": "Roboto Slab, serif",
 					"slug": "roboto-slab",
 					"fontFace": [


### PR DESCRIPTION
Fix the `fontFamily` declaration from `Roboto slab` to `Roboto Slab`.