### PR TITLE
Use get_template_directory_uri for fetching the account icon

### DIFF
--- a/patterns/my-account-icon.php
+++ b/patterns/my-account-icon.php
@@ -11,5 +11,5 @@
 
 ?>
 <!-- wp:image {"sizeSlug":"full","linkDestination":"custom","className":"yith-wonder-my-account-login-icon"} -->
-<figure class="wp-block-image size-full yith-wonder-my-account-login-icon"><a href="<?php echo esc_url( get_permalink( get_option( 'woocommerce_myaccount_page_id' ) ) ); ?>"><img src="<?php echo esc_url( get_theme_file_uri() ); ?>/assets/images/icons/post-author.svg" alt=""></a></figure>
+<figure class="wp-block-image size-full yith-wonder-my-account-login-icon"><a href="<?php echo esc_url( get_permalink( get_option( 'woocommerce_myaccount_page_id' ) ) ); ?>"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/icons/post-author.svg" alt=""></a></figure>
 <!-- /wp:image -->


### PR DESCRIPTION
When generating a child theme for wonder I got this error saying that it could not find the account-icon in the header of the child theme. On exploring a bit I found that `get_theme_file_uri` was returning the child theme directory which would not contain the `assets`. This was an issue that was faced by TT2 as well which was fixed later on, attaching the TT2 fix PR
https://github.com/WordPress/twentytwentytwo/pull/283. This PR does the same fix for account-icon.
![Screenshot 2022-12-05 at 2 24 17 PM](https://user-images.githubusercontent.com/38878906/205594979-c6b50c23-7672-496d-931f-daeec220c235.png)
![Screenshot 2022-12-05 at 2 25 09 PM](https://user-images.githubusercontent.com/38878906/205595150-80685c98-c299-417f-a9b1-f4c1dbb6f5d7.png)


