### PR TITLE
Remove Duplicate `header-titles` Color Declaration in theme.json

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -46,11 +46,6 @@
 					"name": "Header titles"
 				},
 				{
-					"slug": "header-titles",
-					"color": "#007565",
-					"name": "Header titles"
-				},
-				{
 					"slug": "secondary-background",
 					"color": "#e8e8e8",
 					"name": "Secondary background"


### PR DESCRIPTION
This is causing issues in live previews in our Onboarding and for users as they override in Site Editor.